### PR TITLE
Lookup devices cgroup path of target process

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,5 @@ Or in Openshift:
     $ oc create -f test/pod.json
     $ oc get pod test-kvm
     $ oc log test-kvm
+
+(This assumes the pod will run in an SCC with RunAsAny).

--- a/test/pod.json
+++ b/test/pod.json
@@ -9,8 +9,8 @@
             {
                 "name": "fedora",
                 "image": "stefwalter/test-kvm",
-		"user": "root"
+                "user": "root"
             }
-	]
+        ]
     }
 }


### PR DESCRIPTION
At least starting from OpenShift v3.6, origin/k8s creates its own cgroup
hierarchy for QoS purposes:

    # find /sys/fs/cgroup/devices/ -type d -iname 'kube*'
    /sys/fs/cgroup/devices/kubepods.slice
    /sys/fs/cgroup/devices/kubepods.slice/kubepods-besteffort.slice
    /sys/fs/cgroup/devices/kubepods.slice/kubepods-burstable.slice

Sub-slices are created per pod in either directories depending on the
QoS class assigned.

This means that the hardcoded `system.slice` path will not be correct
for pod processes. One can reproduce this from a simple `oc cluster up`
setup.

This patch basically fixes the related TODO in the codebase to make the
hook work in the OpenShift case.

---

Let me know if some parts could be written in more idiomatic Go! I haven't really played much with the language so far.